### PR TITLE
[ci skip] chore: add version_updates with use_curl option

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -7,6 +7,8 @@ azure:
 bot:
   automerge: true
   check_solvable: true
+  version_updates:
+    use_curl: true
 github:
   branch_name: main
   tooling_branch_name: main


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

xref: https://github.com/regro/cf-scripts/pull/5046

The bot used to hardcode a URL from this feedstock, but this option is being used move to feedstock-local configuration via this PR.
